### PR TITLE
Refactor for usability and readability

### DIFF
--- a/count_info.go
+++ b/count_info.go
@@ -1,0 +1,19 @@
+package orchestrator
+
+// workerLoad stores information used to assign tasks to workers.
+type workerLoad struct {
+	worker    Worker
+	taskCount int
+}
+
+// counts looks at each worker and gathers the number of tasks each has.
+func counts(actual, toRemove map[Worker][]interface{}) []workerLoad {
+	var results []workerLoad
+	for k, v := range actual {
+		results = append(results, workerLoad{
+			worker:    k,
+			taskCount: len(v) - len(toRemove[k]),
+		})
+	}
+	return results
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,45 @@
+package orchestrator
+
+import "time"
+
+//OrchestratorOption configures an Orchestrator.
+type OrchestratorOption func(*Orchestrator)
+
+// Logger is used to write information.
+type Logger interface {
+	// Print calls l.Output to print to the logger. Arguments are handled in
+	// the manner of fmt.Print.
+	Printf(format string, v ...interface{})
+}
+
+// WithLogger sets the logger for the Orchestrator. Defaults to silent logger.
+func WithLogger(l Logger) OrchestratorOption {
+	return func(o *Orchestrator) {
+		o.log = l
+	}
+}
+
+// TermStats is the information about the last processed term. It is passed
+// to a stats handler. See WithStats().
+type TermStats struct {
+	// WorkerCount is the number of workers that responded without an error
+	// to a List request.
+	WorkerCount int
+}
+
+// WithStats sets the stats handler for the Orchestrator. The stats handler
+// is invoked for each term, with what the Orchestrator wrote to the
+// Communicator.
+func WithStats(f func(TermStats)) OrchestratorOption {
+	return func(o *Orchestrator) {
+		o.s = f
+	}
+}
+
+// WithCommunicatorTimeout sets the timeout for the communication to respond.
+// Defaults to 10 seconds.
+func WithCommunicatorTimeout(t time.Duration) OrchestratorOption {
+	return func(o *Orchestrator) {
+		o.timeout = t
+	}
+}

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -338,7 +338,7 @@ func (o *Orchestrator) delta(actual map[interface{}][]interface{}) (toAdd map[in
 		if needs == 0 {
 			continue
 		}
-		toAdd[task.Name] = needs
+		toAdd[task.Definition] = needs
 	}
 
 	for worker, tasks := range actual {
@@ -362,7 +362,7 @@ func (o *Orchestrator) delta(actual map[interface{}][]interface{}) (toAdd map[in
 func (o *Orchestrator) hasEnough(t Task, actual map[interface{}][]interface{}) (needs int) {
 	var count int
 	for _, a := range actual {
-		if o.contains(t.Name, a) >= 0 {
+		if o.contains(t.Definition, a) >= 0 {
 			count++
 		}
 	}
@@ -386,7 +386,7 @@ func (o *Orchestrator) contains(x interface{}, y []interface{}) int {
 // task is not found, it returns -1.
 func (o *Orchestrator) containsTask(task interface{}, tasks []Task) int {
 	for i, t := range tasks {
-		if t.Name == task {
+		if t.Definition == task {
 			return i
 		}
 	}
@@ -438,8 +438,8 @@ func (o *Orchestrator) UpdateWorkers(workers []interface{}) {
 
 // Task stores the required information for a task.
 type Task struct {
-	Name      interface{}
-	Instances int
+	Definition interface{}
+	Instances  int
 }
 
 // AddTask adds a new task to the expected workload. The update will not take
@@ -451,12 +451,12 @@ func (o *Orchestrator) AddTask(task interface{}, opts ...TaskOption) {
 
 	// Ensure we don't already have this task
 	for _, t := range o.expectedTasks {
-		if task == t.Name {
+		if task == t.Definition {
 			return
 		}
 	}
 
-	t := Task{Name: task, Instances: 1}
+	t := Task{Definition: task, Instances: 1}
 	for _, opt := range opts {
 		opt(&t)
 	}

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -19,6 +19,28 @@ import (
 	"time"
 )
 
+// Communicator manages the internal communication between the Orchestrator and
+// the node cluster. Each method must be safe to call on many go-routines.
+// The given context represents the state of the term. Therefore, the
+// Communicator is expected to cancel immediately if the context is done.
+type Communicator interface {
+	// List returns the workload from the given worker.
+	List(ctx context.Context, worker interface{}) ([]interface{}, error)
+
+	// Add adds the given task to the worker. The error only logged (for now).
+	// It is assumed that if the worker returns an error trying to update, the
+	// next term will fix the problem and move the task elsewhere.
+	Add(ctx context.Context, worker, taskDefinition interface{}) error
+
+	// Removes the given task from the worker. The error is only logged (for
+	// now). It is assumed that if the worker is returning an error, then it
+	// is either not doing the task because the worker is down, or there is a
+	// network partition and a future term will fix the problem.
+	Remove(ctx context.Context, worker, taskDefinition interface{}) error
+}
+
+type Worker interface{}
+
 // Orchestrator stores the expected workload and reaches out to the cluster
 // to see what the actual workload is. It then tries to fix the delta.
 //
@@ -31,7 +53,7 @@ type Orchestrator struct {
 	timeout time.Duration
 
 	mu            sync.Mutex
-	workers       []interface{}
+	workers       []Worker
 	expectedTasks []Task
 
 	// LastActual is set each term. It is only used for a user who wants to
@@ -55,68 +77,6 @@ func New(c Communicator, opts ...OrchestratorOption) *Orchestrator {
 	return o
 }
 
-//OrchestratorOption configures an Orchestrator.
-type OrchestratorOption func(*Orchestrator)
-
-// Logger is used to write information.
-type Logger interface {
-	// Print calls l.Output to print to the logger. Arguments are handled in
-	// the manner of fmt.Print.
-	Printf(format string, v ...interface{})
-}
-
-// WithLogger sets the logger for the Orchestrator. Defaults to silent logger.
-func WithLogger(l Logger) OrchestratorOption {
-	return func(o *Orchestrator) {
-		o.log = l
-	}
-}
-
-// TermStats is the information about the last processed term. It is passed
-// to a stats handler. See WithStats().
-type TermStats struct {
-	// WorkerCount is the number of workers that responded without an error
-	// to a List request.
-	WorkerCount int
-}
-
-// WithStats sets the stats handler for the Orchestrator. The stats handler
-// is invoked for each term, with what the Orchestrator wrote to the
-// Communicator.
-func WithStats(f func(TermStats)) OrchestratorOption {
-	return func(o *Orchestrator) {
-		o.s = f
-	}
-}
-
-// WithCommunicatorTimeout sets the timeout for the communication to respond.
-// Defaults to 10 seconds.
-func WithCommunicatorTimeout(t time.Duration) OrchestratorOption {
-	return func(o *Orchestrator) {
-		o.timeout = t
-	}
-}
-
-// Communicator manages the intra communication between the Orchestrator and
-// the node cluster. Each method must be safe to call on many go-routines.
-// The given context represents the state of the term. Therefore, the
-// Communicator is expected to cancel immediately if the context is done.
-type Communicator interface {
-	// List returns the workload from the given worker.
-	List(ctx context.Context, worker interface{}) ([]interface{}, error)
-
-	// Add adds the given task to the worker. The error only logged (for now).
-	// It is assumed that if the worker returns an error trying to update, the
-	// next term will fix the problem and move the task elsewhere.
-	Add(ctx context.Context, worker, task interface{}) error
-
-	// Removes the given task from the worker. The error is only logged (for
-	// now). It is assumed that if the worker is returning an error, then it
-	// is either not doing the task because the worker is down, or there is a
-	// network partition and a future term will fix the problem.
-	Remove(ctx context.Context, worker, task interface{}) error
-}
-
 // NextTerm reaches out to the cluster to gather to actual workload. It then
 // attempts to fix the delta between actual and expected. The lifecycle of
 // the term is managed by the given context.
@@ -125,8 +85,7 @@ func (o *Orchestrator) NextTerm(ctx context.Context) {
 	defer o.mu.Unlock()
 
 	// Gather the state of the world from the workers.
-	var actual map[interface{}][]interface{}
-	actual, o.lastActual = o.collectActual(ctx)
+	actual := o.collectActual(ctx)
 	toAdd, toRemove := o.delta(actual)
 
 	// Rebalance tasks among workers.
@@ -141,11 +100,11 @@ func (o *Orchestrator) NextTerm(ctx context.Context) {
 		}
 	}
 
-	for task, missing := range toAdd {
-		history := make(map[interface{}]bool)
+	for taskDefinition, missing := range toAdd {
+		history := make(map[Worker]bool)
 		for i := 0; i < missing; i++ {
 			counts = o.assignTask(ctx,
-				task,
+				taskDefinition,
 				counts,
 				actual,
 				history,
@@ -158,133 +117,13 @@ func (o *Orchestrator) NextTerm(ctx context.Context) {
 	})
 }
 
-// rebalance will rebalance tasks across the workers. If any worker has too
-// many tasks, it will be added to the remove map, and added to the returned
-// add slice.
-func rebalance(
-	toAdd map[interface{}]int,
-	toRemove,
-	actual map[interface{}][]interface{},
-) (map[interface{}]int, map[interface{}][]interface{}) {
-
-	counts := counts(actual, toRemove)
-	if len(counts) == 0 {
-		return toAdd, toRemove
-	}
-
-	var total int
-	for _, c := range counts {
-		total += c.count
-	}
-
-	for _, addCount := range toAdd {
-		total += addCount
-	}
-
-	maxPerNode := total / len(counts)
-	if maxPerNode == 0 || total%len(counts) != 0 {
-		maxPerNode++
-	}
-
-	for _, c := range counts {
-		if c.count > maxPerNode {
-			task := actual[c.name][0]
-			toRemove[c.name] = append(toRemove[c.name], task)
-			toAdd[task]++
-		}
-	}
-
-	return toAdd, toRemove
-}
-
-// assignTask tries to find a worker that does not have too many tasks
-// assigned. If it encounters a worker with too many tasks, it will remove
-// it from the pool and try again.
-func (o *Orchestrator) assignTask(
-	ctx context.Context,
-	task interface{},
-	counts []countInfo,
-	actual map[interface{}][]interface{},
-	history map[interface{}]bool,
-) []countInfo {
-
-	for i, info := range counts {
-		// Ensure that each worker gets an even amount of work assigned.
-		// Therefore if a worker gets its fair share, remove it from the worker
-		// pool for this term. This also accounts for there being a non-divisbile
-		// amount of tasks per workers.
-		info.count++
-		activeWorkers := len(actual)
-		totalTasks := o.totalTaskCount()
-		if info.count > totalTasks/activeWorkers+totalTasks%activeWorkers {
-			counts = append(counts[:i], counts[i+1:]...)
-
-			// Return true saying the worker pool was adjusted and the task was
-			// not assigned.
-			return o.assignTask(ctx, task, counts, actual, history)
-		}
-
-		// Ensure we haven't assigned this task to the worker already.
-		if history[info.name] || contains(task, actual[info.name]) >= 0 {
-			continue
-		}
-		history[info.name] = true
-
-		// Update the count for the worker.
-		counts[i] = countInfo{
-			name:  info.name,
-			count: info.count,
-		}
-
-		// Assign the task to the worker.
-		o.log.Printf("Adding task %s to %s.", task, info.name)
-		addCtx, _ := context.WithTimeout(ctx, o.timeout)
-		o.c.Add(addCtx, info.name, task)
-
-		// Move adjusted count to end of slice to help with fairness
-		c := counts[i]
-		counts = append(append(counts[:i], counts[i+1:]...), c)
-
-		break
-	}
-
-	return counts
-}
-
-// totalTaskCount calculates the total number of expected task instances.
-func (o *Orchestrator) totalTaskCount() int {
-	var total int
-	for _, t := range o.expectedTasks {
-		total += t.Instances
-	}
-	return total
-}
-
-// countInfo stores information used to assign tasks to workers.
-type countInfo struct {
-	name  interface{}
-	count int
-}
-
-// counts looks at each worker and gathers the number of tasks each has.
-func counts(actual, toRemove map[interface{}][]interface{}) []countInfo {
-	var results []countInfo
-	for k, v := range actual {
-		results = append(results, countInfo{
-			name:  k,
-			count: len(v) - len(toRemove[k]),
-		})
-	}
-	return results
-}
-
 // collectActual reaches out to each worker and gets their state of the world.
 // Each worker is queried in parallel. If a worker returns an error while
 // trying to list the tasks, it will be logged and not considered for what
 // workers should be assigned work.
-func (o *Orchestrator) collectActual(ctx context.Context) (map[interface{}][]interface{}, []WorkerState) {
+func (o *Orchestrator) collectActual(ctx context.Context) map[Worker][]interface{} {
 	type result struct {
-		name   interface{}
+		worker Worker
 		actual []interface{}
 		err    error
 	}
@@ -293,48 +132,50 @@ func (o *Orchestrator) collectActual(ctx context.Context) (map[interface{}][]int
 	results := make(chan result, len(o.workers))
 	errs := make(chan result, len(o.workers))
 	for _, worker := range o.workers {
-		go func(worker interface{}) {
-			r, err := o.c.List(listCtx, worker)
+		go func(worker Worker) {
+			listResults, err := o.c.List(listCtx, worker)
 			if err != nil {
-				errs <- result{name: worker, err: err}
+				errs <- result{worker: worker, err: err}
 				return
 			}
 
-			results <- result{name: worker, actual: r}
+			results <- result{worker: worker, actual: listResults}
 		}(worker)
 	}
 
 	t := time.NewTimer(o.timeout)
 	var state []WorkerState
-	actual := make(map[interface{}][]interface{})
+	actual := make(map[Worker][]interface{})
 	for i := 0; i < len(o.workers); i++ {
 		select {
 		case <-ctx.Done():
 			break
-		case r := <-results:
-			actual[r.name] = r.actual
-			state = append(state, WorkerState{Name: r.name, Tasks: r.actual})
+		case nextResult := <-results:
+			actual[nextResult.worker] = nextResult.actual
+			state = append(state, WorkerState{Worker: nextResult.worker, Tasks: nextResult.actual})
 		case err := <-errs:
-			o.log.Printf("Error trying to list tasks from %s: %s", err.name, err.err)
+			o.log.Printf("Error trying to list tasks from %s: %s", err.worker, err.err)
 		case <-t.C:
 			o.log.Printf("Communicator timeout. Using results available...")
 			break
 		}
 	}
 
-	return actual, state
+	o.lastActual = state
+	return actual
 }
 
 // delta finds what should be added and removed to make actual match the
 // expected.
-func (o *Orchestrator) delta(actual map[interface{}][]interface{}) (toAdd map[interface{}]int, toRemove map[interface{}][]interface{}) {
-	toRemove = make(map[interface{}][]interface{})
+func (o *Orchestrator) delta(actual map[Worker][]interface{}) (toAdd map[interface{}]int, toRemove map[Worker][]interface{}) {
 	toAdd = make(map[interface{}]int)
+	toRemove = make(map[Worker][]interface{})
+
 	expectedTasks := make([]Task, len(o.expectedTasks))
 	copy(expectedTasks, o.expectedTasks)
 
 	for _, task := range o.expectedTasks {
-		needs := hasEnough(task, actual)
+		needs := hasEnoughInstances(task, actual)
 		if needs == 0 {
 			continue
 		}
@@ -357,9 +198,240 @@ func (o *Orchestrator) delta(actual map[interface{}][]interface{}) (toAdd map[in
 	return toAdd, toRemove
 }
 
-// hasEnough looks at each task in the given actual list and ensures
+// assignTask tries to find a worker that does not have too many tasks
+// assigned. If it encounters a worker with too many tasks, it will remove
+// it from the pool and try again.
+func (o *Orchestrator) assignTask(
+	ctx context.Context,
+	taskDefinition interface{},
+	workerLoads []workerLoad,
+	actual map[Worker][]interface{},
+	history map[Worker]bool,
+) []workerLoad {
+	activeWorkers := len(actual)
+	totalTasks := o.totalTaskCount()
+	maxTaskCount := totalTasks/activeWorkers + totalTasks%activeWorkers
+
+	for i, loadInfo := range workerLoads {
+		// Ensure that each worker gets an even amount of work assigned.
+		// Therefore if a worker gets its fair share, remove it from the worker
+		// pool for this term. This also accounts for there being a non-divisible
+		// amount of tasks per workers.
+		loadInfo.taskCount++
+		if loadInfo.taskCount > maxTaskCount {
+			workerLoads = append(workerLoads[:i], workerLoads[i+1:]...)
+
+			// Recurse since the worker pool was adjusted and the task was
+			// not assigned.
+			return o.assignTask(ctx, taskDefinition, workerLoads, actual, history)
+		}
+
+		// Ensure we haven't assigned this task to the worker already.
+		if history[loadInfo.worker] || contains(taskDefinition, actual[loadInfo.worker]) >= 0 {
+			continue
+		}
+		history[loadInfo.worker] = true
+
+		// Assign the task to the worker.
+		o.log.Printf("Adding task %s to %s.", taskDefinition, loadInfo.worker)
+		addCtx, _ := context.WithTimeout(ctx, o.timeout)
+		o.c.Add(addCtx, loadInfo.worker, taskDefinition)
+
+		// Move updated count to end of slice to help with fairness
+		workerLoads = append(
+			append(workerLoads[:i], workerLoads[i+1:]...),
+			workerLoad{
+				worker:    loadInfo.worker,
+				taskCount: loadInfo.taskCount,
+			},
+		)
+
+		break
+	}
+
+	return workerLoads
+}
+
+// totalTaskCount calculates the total number of expected task instances.
+func (o *Orchestrator) totalTaskCount() int {
+	var total int
+	for _, t := range o.expectedTasks {
+		total += t.Instances
+	}
+	return total
+}
+
+// AddWorker adds a worker to the known worker cluster. The update will not
+// take affect until the next term. It is safe to invoke AddWorker,
+// RemoveWorkers and UpdateWorkers on multiple go-routines.
+func (o *Orchestrator) AddWorker(worker Worker) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// Ensure we don't already have this worker
+	for _, w := range o.workers {
+		if w == worker {
+			return
+		}
+	}
+
+	o.workers = append(o.workers, worker)
+}
+
+// RemoveWorker removes a worker from the known worker cluster. The update
+// will not take affect until the next term. It is safe to invoke AddWorker,
+// RemoveWorkers and UpdateWorkers on multiple go-routines.
+func (o *Orchestrator) RemoveWorker(worker Worker) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	idx := containsWorker(worker, o.workers)
+	if idx < 0 {
+		return
+	}
+
+	o.workers = append(o.workers[:idx], o.workers[idx+1:]...)
+}
+
+// UpdateWorkers overwrites the expected worker list. The update will not take
+// affect until the next term. It is safe to invoke AddWorker, RemoveWorker
+// and UpdateWorkers on multiple go-routines.
+func (o *Orchestrator) UpdateWorkers(workers []Worker) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.workers = workers
+}
+
+// Task stores the required information for a task.
+type Task struct {
+	Definition interface{}
+	Instances  int
+}
+
+// AddTask adds a new task to the expected workload. The update will not take
+// affect until the next term. It is safe to invoke AddTask, RemoveTask and
+// UpdateTasks on multiple go-routines.
+func (o *Orchestrator) AddTask(taskDefinition interface{}, opts ...TaskOption) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// Ensure we don't already have this task
+	for _, t := range o.expectedTasks {
+		if taskDefinition == t.Definition {
+			return
+		}
+	}
+
+	t := Task{Definition: taskDefinition, Instances: 1}
+	for _, opt := range opts {
+		opt(&t)
+	}
+
+	o.expectedTasks = append(o.expectedTasks, t)
+}
+
+// TaskOption is used to configure a task when it is being added.
+type TaskOption func(*Task)
+
+// WithTaskInstances configures the number of tasks. Defaults to 1.
+func WithTaskInstances(i int) TaskOption {
+	return func(t *Task) {
+		t.Instances = i
+	}
+}
+
+// RemoveTask removes a task from the expected workload. The update will not
+// take affect until the next term. It is safe to invoke AddTask, RemoveTask
+// and UpdateTasks on multiple go-routines.
+func (o *Orchestrator) RemoveTask(taskDefinition interface{}) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	idx := containsTask(taskDefinition, o.expectedTasks)
+	if idx < 0 {
+		return
+	}
+
+	o.expectedTasks = append(o.expectedTasks[:idx], o.expectedTasks[idx+1:]...)
+}
+
+// UpdateTasks overwrites the expected task list. The update will not take
+// affect until the next term. It is safe to invoke AddTask, RemoveTask and
+// UpdateTasks on multiple go-routines.
+func (o *Orchestrator) UpdateTasks(tasks []Task) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.expectedTasks = tasks
+}
+
+// ListExpectedTasks returns the current list of the expected tasks.
+func (o *Orchestrator) ListExpectedTasks() []Task {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.expectedTasks
+}
+
+// WorkerState stores the state of a worker.
+type WorkerState struct {
+	Worker Worker
+
+	// Tasks are the task definitions the worker is servicing.
+	Tasks []interface{}
+}
+
+// LastActual returns the actual from the last term. It will return nil
+// before the first term.
+func (o *Orchestrator) LastActual() []WorkerState {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	return o.lastActual
+}
+
+// rebalance will rebalance tasks across the workers. If any worker has too
+// many tasks, it will be added to the remove map, and added to the returned
+// add slice.
+func rebalance(
+	toAdd map[interface{}]int,
+	toRemove,
+	actual map[Worker][]interface{},
+) (map[interface{}]int, map[Worker][]interface{}) {
+
+	counts := counts(actual, toRemove)
+	if len(counts) == 0 {
+		return toAdd, toRemove
+	}
+
+	var total int
+	for _, c := range counts {
+		total += c.taskCount
+	}
+
+	for _, addCount := range toAdd {
+		total += addCount
+	}
+
+	maxPerNode := total / len(counts)
+	if maxPerNode == 0 || total%len(counts) != 0 {
+		maxPerNode++
+	}
+
+	for _, c := range counts {
+		if c.taskCount > maxPerNode {
+			task := actual[c.worker][0]
+			toRemove[c.worker] = append(toRemove[c.worker], task)
+			toAdd[task]++
+		}
+	}
+
+	return toAdd, toRemove
+}
+
+// hasEnoughInstances looks at each task in the given actual list and ensures
 // a worker node is servicing the task.
-func hasEnough(t Task, actual map[interface{}][]interface{}) (needs int) {
+func hasEnoughInstances(t Task, actual map[Worker][]interface{}) (needs int) {
 	var count int
 	for _, a := range actual {
 		if contains(t.Definition, a) >= 0 {
@@ -394,132 +466,14 @@ func containsTask(task interface{}, tasks []Task) int {
 	return -1
 }
 
-// AddWorker adds a worker to the known worker cluster. The update will not
-// take affect until the next term. It is safe to invoke AddWorker,
-// RemoveWorkers and UpdateWorkers on multiple go-routines.
-func (o *Orchestrator) AddWorker(worker interface{}) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	// Ensure we don't alreay have this worker
-	for _, w := range o.workers {
+// containsWorker returns the index of the given worker name in the workers. If the
+// worker is not found, it returns -1.
+func containsWorker(worker Worker, workers []Worker) int {
+	for i, w := range workers {
 		if w == worker {
-			return
+			return i
 		}
 	}
 
-	o.workers = append(o.workers, worker)
-}
-
-// RemoveWorker removes a worker from the known worker cluster. The update
-// will not take affect until the next term. It is safe to invoke AddWorker,
-// RemoveWorkers and UpdateWorkers on multiple go-routines.
-func (o *Orchestrator) RemoveWorker(worker interface{}) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	idx := contains(worker, o.workers)
-	if idx < 0 {
-		return
-	}
-
-	o.workers = append(o.workers[:idx], o.workers[idx+1:]...)
-}
-
-// UpdateWorkers overwrites the expected worker list. The update will not take
-// affect until the next term. It is safe to invoke AddWorker, RemoveWorker
-// and UpdateWorkers on multiple go-routines.
-func (o *Orchestrator) UpdateWorkers(workers []interface{}) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	o.workers = workers
-}
-
-// Task stores the required information for a task.
-type Task struct {
-	Definition interface{}
-	Instances  int
-}
-
-// AddTask adds a new task to the expected workload. The update will not take
-// affect until the next term. It is safe to invoke AddTask, RemoveTask and
-// UpdateTasks on multiple go-routines.
-func (o *Orchestrator) AddTask(task interface{}, opts ...TaskOption) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	// Ensure we don't already have this task
-	for _, t := range o.expectedTasks {
-		if task == t.Definition {
-			return
-		}
-	}
-
-	t := Task{Definition: task, Instances: 1}
-	for _, opt := range opts {
-		opt(&t)
-	}
-
-	o.expectedTasks = append(o.expectedTasks, t)
-}
-
-// TaskOption is used to configure a task when it is being added.
-type TaskOption func(*Task)
-
-// WithTaskInstances configures the number of tasks. Defaults to 1.
-func WithTaskInstances(i int) TaskOption {
-	return func(t *Task) {
-		t.Instances = i
-	}
-}
-
-// RemoveTask removes a task from the expected workload. The update will not
-// take affect until the next term. It is safe to invoke AddTask, RemoveTask
-// and UpdateTasks on multiple go-routines.
-func (o *Orchestrator) RemoveTask(task interface{}) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	idx := containsTask(task, o.expectedTasks)
-	if idx < 0 {
-		return
-	}
-
-	o.expectedTasks = append(o.expectedTasks[:idx], o.expectedTasks[idx+1:]...)
-}
-
-// UpdateTasks overwrites the expected task list. The update will not take
-// affect until the next term. It is safe to invoke AddTask, RemoveTask and
-// UpdateTasks on multiple go-routines.
-func (o *Orchestrator) UpdateTasks(tasks []Task) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	o.expectedTasks = tasks
-}
-
-// ListExpectedTasks returns the curent list of the expected tasks.
-func (o *Orchestrator) ListExpectedTasks() []Task {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	return o.expectedTasks
-}
-
-// WorkerState stores the state of a worker.
-type WorkerState struct {
-	// Name is the given name of a worker.
-	Name interface{}
-
-	// Tasks is the task names the worker is servicing.
-	Tasks []interface{}
-}
-
-// LastActual returns the actual from the last term. It will return nil
-// before the first term.
-func (o *Orchestrator) LastActual() []WorkerState {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	return o.lastActual
+	return -1
 }

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -164,7 +164,7 @@ func TestOrchestrator(t *testing.T) {
 
 			o.Group("with single worker", func() {
 				o.Spec("it only assigns the task once", func(t TO) {
-					t.o.UpdateWorkers([]interface{}{"worker"})
+					t.o.UpdateWorkers([]orchestrator.Worker{"worker"})
 					t.spy.actual["worker"] = []interface{}{"multi-task"}
 					t.o.AddTask("multi-task", orchestrator.WithTaskInstances(2))
 
@@ -328,7 +328,7 @@ func TestOrchestrator(t *testing.T) {
 				t.spy.actual["worker-0"] = []interface{}{"task-0"}
 				t.spy.actual["worker-2"] = []interface{}{"task-2"}
 
-				t.o.UpdateWorkers([]interface{}{"worker-0", "worker-2"})
+				t.o.UpdateWorkers([]orchestrator.Worker{"worker-0", "worker-2"})
 				return t
 			})
 

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	orchestrator "code.cloudfoundry.org/go-orchestrator"
+	"code.cloudfoundry.org/go-orchestrator"
 	"github.com/apoydence/onpar"
 	. "github.com/apoydence/onpar/expect"
 	. "github.com/apoydence/onpar/matchers"
@@ -382,12 +382,12 @@ func TestOrchestrator(t *testing.T) {
 
 				t.o.UpdateTasks([]orchestrator.Task{
 					{
-						Name:      "task-0",
-						Instances: 1,
+						Definition: "task-0",
+						Instances:  1,
 					},
 					{
-						Name:      "task-2",
-						Instances: 1,
+						Definition: "task-2",
+						Instances:  1,
 					},
 				})
 				return t


### PR DESCRIPTION
Note: this is a breaking change

* Change worker to include its own communicator and an identifier
  * Remove worker from communicator signatures
* Change Task name to Task definition
* Reorganize tests to fit with their group descriptions